### PR TITLE
Add "Enable Gradient Color" option for CPU and Memory usage bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ iGlance/iGlance\.xcodeproj/project\.xcworkspace/
 iGlance/iGlance\.xcodeproj/xcuserdata/
 
 *.DS_Store
+
+.idea

--- a/iGlance/iGlance.xcodeproj/project.pbxproj
+++ b/iGlance/iGlance.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		B4EF0F3E2184CE3D00A28F5E /* FanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF0F3D2184CE3D00A28F5E /* FanView.swift */; };
 		B4EF0F402184CEA800A28F5E /* NetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF0F3F2184CEA800A28F5E /* NetworkView.swift */; };
 		B4FF095120D02270006BE560 /* BatteryComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FF095020D02270006BE560 /* BatteryComponent.swift */; };
+		D574CB478F9CB8632C3F5178 /* GradientImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D574CD590FABD2E739D0B44C /* GradientImage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -94,6 +95,7 @@
 		B4EF0F3D2184CE3D00A28F5E /* FanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FanView.swift; sourceTree = "<group>"; };
 		B4EF0F3F2184CEA800A28F5E /* NetworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkView.swift; sourceTree = "<group>"; };
 		B4FF095020D02270006BE560 /* BatteryComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryComponent.swift; sourceTree = "<group>"; };
+		D574CD590FABD2E739D0B44C /* GradientImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientImage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +181,7 @@
 			isa = PBXGroup;
 			children = (
 				B4A54A902218723200957E17 /* MenuBarGraph.swift */,
+				D574CD590FABD2E739D0B44C /* GradientImage.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 				B4DD136A21F3C59C00652861 /* MemUsageComponent.swift in Sources */,
 				02B8120920C95D6600C98F0D /* CPUMenuView.swift in Sources */,
 				025AC38B20C0AFDD000E0837 /* AppDelegate.swift in Sources */,
+				D574CB478F9CB8632C3F5178 /* GradientImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iGlance/iGlance/AppDelegate.swift
+++ b/iGlance/iGlance/AppDelegate.swift
@@ -70,10 +70,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         static var userWantsCPUUtil = false
         static var userWantsCPUTemp = false
         static var userWantsAutostart = false
-        static var cpuColor = NSColor.red
+        static var cpuColor = NSColor.green
+        static var cpuColor2 = NSColor.red
         static var cpuUsageVisualization = VisualizationType.Bar
         static var cpuGraphWidth = 27
         static var memColor = NSColor.green
+        static var memColor2 = NSColor.red
         static var memUsageVisualization = VisualizationType.Bar
         static var memGraphWidth = 27
         static var updateInterval = 1.0
@@ -84,6 +86,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         static var userWantsBatteryNotification = true
         static var lowerBatteryNotificationValue = 20
         static var upperBatteryNotificationValue = 80
+        static var userWantsCPUGradientColor = false
+        static var userWantsMemGradientColor = false
     }
 
     /**
@@ -274,12 +278,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             UserSettings.memColor = NSColor(calibratedRed: colRedMem, green: colGreenMem, blue: colBlueMem, alpha: colAlphaMem)
         }
 
+        if UserDefaults.standard.value(forKey: "colRedMem2") != nil {
+            let red = UserDefaults.standard.value(forKey: "colRedMem2") as! CGFloat
+            let green = UserDefaults.standard.value(forKey: "colGreenMem2") as! CGFloat
+            let blue = UserDefaults.standard.value(forKey: "colBlueMem2") as! CGFloat
+            let alpha = UserDefaults.standard.value(forKey: "colAlphaMem2") as! CGFloat
+            UserSettings.memColor2 = NSColor(calibratedRed: red, green: green, blue: blue, alpha: alpha)
+        }
+
         if UserDefaults.standard.value(forKey: "colRedCPU") != nil {
             colRedCPU = UserDefaults.standard.value(forKey: "colRedCPU") as! CGFloat
             colGreenCPU = UserDefaults.standard.value(forKey: "colGreenCPU") as! CGFloat
             colBlueCPU = UserDefaults.standard.value(forKey: "colBlueCPU") as! CGFloat
             colAlphaCPU = UserDefaults.standard.value(forKey: "colAlphaCPU") as! CGFloat
             UserSettings.cpuColor = NSColor(calibratedRed: colRedCPU, green: colGreenCPU, blue: colBlueCPU, alpha: colAlphaCPU)
+        }
+
+        if UserDefaults.standard.value(forKey: "colRedCPU2") != nil {
+            let red = UserDefaults.standard.value(forKey: "colRedCPU2") as! CGFloat
+            let green = UserDefaults.standard.value(forKey: "colGreenCPU2") as! CGFloat
+            let blue = UserDefaults.standard.value(forKey: "colBlueCPU2") as! CGFloat
+            let alpha = UserDefaults.standard.value(forKey: "colAlphaCPU2") as! CGFloat
+            UserSettings.cpuColor2 = NSColor(calibratedRed: red, green: green, blue: blue, alpha: alpha)
         }
 
         if UserDefaults.standard.value(forKey: "userWantsCPUUtil") != nil {
@@ -323,8 +343,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if UserDefaults.standard.value(forKey: "userWantsCPUBorder") != nil {
             UserSettings.userWantsCPUBorder = UserDefaults.standard.value(forKey: "userWantsCPUBorder") as! Bool
         }
+        if UserDefaults.standard.value(forKey: "userWantsCPUGradientColor") != nil {
+            UserSettings.userWantsCPUGradientColor = UserDefaults.standard.value(forKey: "userWantsCPUGradientColor") as! Bool
+        }
         if UserDefaults.standard.value(forKey: "userWantsMemBorder") != nil {
             UserSettings.userWantsMemBorder = UserDefaults.standard.value(forKey: "userWantsMemBorder") as! Bool
+        }
+        if UserDefaults.standard.value(forKey: "userWantsMemGradientColor") != nil {
+            UserSettings.userWantsMemGradientColor = UserDefaults.standard.value(forKey: "userWantsMemGradientColor") as! Bool
         }
         if UserDefaults.standard.value(forKey: "userWantsBatteryUtil") != nil {
             UserSettings.userWantsBatteryUtil = UserDefaults.standard.value(forKey: "userWantsBatteryUtil") as! Bool

--- a/iGlance/iGlance/Base.lproj/Main.storyboard
+++ b/iGlance/iGlance/Base.lproj/Main.storyboard
@@ -1079,18 +1079,49 @@
                                     <action selector="cpCPU_clicked:" target="MQx-3P-zDy" id="Ys9-Jz-cEt"/>
                                 </connections>
                             </colorWell>
+                            <button hidden="YES" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJc-tX-5GW" userLabel="Cb CPU Enable ColorGradient">
+                                <rect key="frame" x="18" y="44" width="202" height="28"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Enable Color Gradient" bezelStyle="regularSquare" imagePosition="left" inset="2" id="qhp-Bv-TAE">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="cbCPUEnableColorGradient_clicked:" target="MQx-3P-zDy" id="Wjq-Ss-baN"/>
+                                </connections>
+                            </button>
+                            <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="F5G-9s-e7t" userLabel="Second Color Label">
+                                <rect key="frame" x="18" y="18" width="90" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Second Color:" id="QwU-jx-yac">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <colorWell hidden="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IuU-qN-G20" userLabel="cpCPU2">
+                                <rect key="frame" x="158" y="15" width="48" height="23"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <color key="color" name="systemRedColor" catalog="System" colorSpace="catalog"/>
+                                <connections>
+                                    <action selector="cpCPU2_clicked:" target="MQx-3P-zDy" id="NLz-Gt-f9p"/>
+                                </connections>
+                            </colorWell>
                         </subviews>
                     </view>
                     <connections>
                         <outlet property="cbCPUBorder" destination="9PU-LC-0gS" id="9Yt-hE-cby"/>
+                        <outlet property="cbCPUEnableColorGradient" destination="MJc-tX-5GW" id="OUl-1A-zlc"/>
                         <outlet property="cbCPUTemp" destination="TfC-J4-Qzk" id="CFQ-fy-GHR"/>
                         <outlet property="cbCPUUtil" destination="gpa-qj-kWb" id="uJJ-Qs-xPL"/>
                         <outlet property="cpCPU" destination="W9N-7k-Xkt" id="O3a-jZ-g0I"/>
+                        <outlet property="cpCPU2" destination="IuU-qN-G20" id="WyU-fm-3Nc"/>
                         <outlet property="cpuGraphwidth" destination="hUK-V9-6cd" id="dyb-Yp-lSo"/>
                         <outlet property="ddTempUnit" destination="28T-ir-Zeo" id="ZfR-04-r5c"/>
                         <outlet property="graphPixelLabel" destination="Ad9-eq-aFz" id="ool-Tg-q0t"/>
                         <outlet property="graphWidthLabel" destination="xb0-K8-gTX" id="qBV-Dz-pka"/>
                         <outlet property="popUpCPUGraphType" destination="v9K-rV-SwD" id="LC9-gL-f3o"/>
+                        <outlet property="secondColorLabel" destination="F5G-9s-e7t" id="nud-hG-I6h"/>
                     </connections>
                 </viewController>
                 <customObject id="gG7-L0-jME" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1201,16 +1232,47 @@
                                     <action selector="memGraphWidth:" target="rub-dP-mB3" id="E3h-l0-wEF"/>
                                 </connections>
                             </textField>
+                            <button hidden="YES" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1lW-Gc-zro" userLabel="Cb Mem Enable Color Gradient">
+                                <rect key="frame" x="18" y="128" width="202" height="28"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Enable Color Gradient" bezelStyle="regularSquare" imagePosition="left" inset="2" id="1mi-Cr-IHn">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="cbMemEnableColorGradient_clicked:" target="rub-dP-mB3" id="clq-w0-ShX"/>
+                                </connections>
+                            </button>
+                            <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TUm-N4-2vE" userLabel="Second Color Label">
+                                <rect key="frame" x="18" y="102" width="90" height="17"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Second Color:" id="ar7-fs-lY9">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <colorWell hidden="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mm7-Ol-rWO" userLabel="Cp Mem2">
+                                <rect key="frame" x="142" y="99" width="48" height="23"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <color key="color" name="systemRedColor" catalog="System" colorSpace="catalog"/>
+                                <connections>
+                                    <action selector="cpMem2_clicked:" target="rub-dP-mB3" id="Pje-Df-OPo"/>
+                                </connections>
+                            </colorWell>
                         </subviews>
                     </view>
                     <connections>
                         <outlet property="cbMemBorder" destination="MDb-0Z-pJj" id="AzB-sH-VTt"/>
+                        <outlet property="cbMemEnableColorGradient" destination="1lW-Gc-zro" id="pe5-Wj-jWR"/>
                         <outlet property="cbMemUtil" destination="v1t-v1-O2M" id="0Vi-Hy-f6e"/>
+                        <outlet property="cpMem2" destination="mm7-Ol-rWO" id="pQ4-Yc-NHI"/>
                         <outlet property="cpMemUtil" destination="mgz-kS-K4o" id="ykX-lu-Z88"/>
                         <outlet property="memGraphPixelLabel" destination="hsA-Yi-6fk" id="wot-cP-bKr"/>
                         <outlet property="memGraphWidth" destination="rZF-fk-xVj" id="F36-4w-auD"/>
                         <outlet property="memGraphWidthLabel" destination="nU2-Ne-Jy4" id="U5B-DG-vQi"/>
                         <outlet property="popUpMemoryVisualization" destination="up5-am-q4S" id="If7-GB-c7Q"/>
+                        <outlet property="secondColorLabel" destination="TUm-N4-2vE" id="qDp-NR-NfU"/>
                     </connections>
                 </viewController>
                 <customObject id="5NP-Qv-Hqp" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/iGlance/iGlance/SettingsWindowViews/CpuView.swift
+++ b/iGlance/iGlance/SettingsWindowViews/CpuView.swift
@@ -144,6 +144,10 @@ class CpuView: NSViewController {
         cpuGraphwidth.isHidden = popUpCPUGraphType.indexOfSelectedItem == 0
         graphPixelLabel.isHidden = cpuGraphwidth.isHidden
         graphWidthLabel.isHidden = cpuGraphwidth.isHidden
+        // hide/show second color related controls
+        cbCPUEnableColorGradient.isHidden = (AppDelegate.UserSettings.cpuUsageVisualization == AppDelegate.VisualizationType.Graph)
+        secondColorLabel.isHidden = !shouldShowSecondColorControls()
+        cpCPU2.isHidden = !shouldShowSecondColorControls()
     }
     
     // outlets and actions of the labels and textfield to define the width of the menu bar graph
@@ -175,4 +179,47 @@ class CpuView: NSViewController {
     }
     @IBOutlet weak var graphPixelLabel: NSTextField!
     @IBOutlet weak var graphWidthLabel: NSTextField!
+
+    // define the outlet and the action of the color well to choose second color
+    @IBOutlet var cpCPU2: NSColorWell! {
+        didSet {
+            cpCPU2.color = AppDelegate.UserSettings.cpuColor2
+            cpCPU2.isHidden = !shouldShowSecondColorControls()
+        }
+    }
+
+    @IBAction func cpCPU2_clicked(_ sender: NSColorWell) {
+        AppDelegate.UserSettings.cpuColor2 = sender.color
+        var red: CGFloat = 0, blue: CGFloat = 0, green: CGFloat = 0, alpha: CGFloat = 0
+        sender.color.usingColorSpace(NSColorSpace.genericRGB)?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        UserDefaults.standard.set(CGFloat(round(red * 10000) / 10000), forKey: "colRedCPU2")
+        UserDefaults.standard.set(CGFloat(round(green * 10000) / 10000), forKey: "colGreenCPU2")
+        UserDefaults.standard.set(CGFloat(round(blue * 10000) / 10000), forKey: "colBlueCPU2")
+        UserDefaults.standard.set(CGFloat(round(alpha * 10000) / 10000), forKey: "colAlphaCPU2")
+    }
+
+    @IBOutlet var cbCPUEnableColorGradient: NSButton! {
+        didSet {
+            cbCPUEnableColorGradient.isHidden = (AppDelegate.UserSettings.cpuUsageVisualization == AppDelegate.VisualizationType.Graph)
+            cbCPUEnableColorGradient.state = AppDelegate.UserSettings.userWantsCPUGradientColor ? NSButton.StateValue.on : NSButton.StateValue.off
+        }
+    }
+
+    @IBAction func cbCPUEnableColorGradient_clicked(_: NSButton) {
+        AppDelegate.UserSettings.userWantsCPUGradientColor = (cbCPUEnableColorGradient.state == NSButton.StateValue.on)
+        UserDefaults.standard.set((cbCPUEnableColorGradient.state == NSButton.StateValue.on), forKey: "userWantsCPUGradientColor")
+        secondColorLabel.isHidden = !shouldShowSecondColorControls()
+        cpCPU2.isHidden = !shouldShowSecondColorControls()
+    }
+
+    @IBOutlet weak var secondColorLabel: NSTextField! {
+        didSet {
+            secondColorLabel.isHidden = !shouldShowSecondColorControls()
+        }
+    }
+
+    private func shouldShowSecondColorControls() -> Bool {
+        return (AppDelegate.UserSettings.userWantsCPUGradientColor
+                && AppDelegate.UserSettings.cpuUsageVisualization == AppDelegate.VisualizationType.Bar)
+    }
 }

--- a/iGlance/iGlance/SettingsWindowViews/MemoryView.swift
+++ b/iGlance/iGlance/SettingsWindowViews/MemoryView.swift
@@ -105,6 +105,11 @@ class MemoryView: NSViewController {
         memGraphWidth.isHidden = popUpMemoryVisualization.indexOfSelectedItem == 0
         memGraphPixelLabel.isHidden = memGraphWidth.isHidden
         memGraphWidthLabel.isHidden = memGraphWidth.isHidden
+
+        // hide/show second color related controls
+        cbMemEnableColorGradient.isHidden = (AppDelegate.UserSettings.memUsageVisualization == AppDelegate.VisualizationType.Graph)
+        secondColorLabel.isHidden = !shouldShowSecondColorControls()
+        cpMem2.isHidden = !shouldShowSecondColorControls()
     }
     
     @IBOutlet weak var memGraphWidthLabel: NSTextField!
@@ -135,5 +140,48 @@ class MemoryView: NSViewController {
             memGraphWidth.intValue = UserDefaults.standard.value(forKey: "memGraphWidth") as! Int32
         }
         
+    }
+
+    @IBOutlet var cbMemEnableColorGradient: NSButton! {
+        didSet {
+            cbMemEnableColorGradient.isHidden = (AppDelegate.UserSettings.memUsageVisualization == AppDelegate.VisualizationType.Graph)
+            cbMemEnableColorGradient.state = AppDelegate.UserSettings.userWantsMemGradientColor ? NSButton.StateValue.on : NSButton.StateValue.off
+        }
+    }
+
+    @IBAction func cbMemEnableColorGradient_clicked(_: NSButton) {
+        AppDelegate.UserSettings.userWantsMemGradientColor = (cbMemEnableColorGradient.state == NSButton.StateValue.on)
+        UserDefaults.standard.set(AppDelegate.UserSettings.userWantsMemGradientColor, forKey: "userWantsMemGradientColor")
+        secondColorLabel.isHidden = !shouldShowSecondColorControls()
+        cpMem2.isHidden = !shouldShowSecondColorControls()
+    }
+
+    @IBOutlet weak var secondColorLabel: NSTextField! {
+        didSet {
+            secondColorLabel.isHidden = !shouldShowSecondColorControls()
+        }
+    }
+
+    // define the outlet and the action of the color well to choose second color
+    @IBOutlet var cpMem2: NSColorWell! {
+        didSet {
+            cpMem2.color = AppDelegate.UserSettings.memColor2
+            cpMem2.isHidden = !shouldShowSecondColorControls()
+        }
+    }
+
+    @IBAction func cpMem2_clicked(_ sender: NSColorWell) {
+        AppDelegate.UserSettings.memColor2 = sender.color
+        var red: CGFloat = 0, blue: CGFloat = 0, green: CGFloat = 0, alpha: CGFloat = 0
+        sender.color.usingColorSpace(NSColorSpace.genericRGB)?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        UserDefaults.standard.set(CGFloat(round(red * 10000) / 10000), forKey: "colRedMem2")
+        UserDefaults.standard.set(CGFloat(round(green * 10000) / 10000), forKey: "colGreenMem2")
+        UserDefaults.standard.set(CGFloat(round(blue * 10000) / 10000), forKey: "colBlueMem2")
+        UserDefaults.standard.set(CGFloat(round(alpha * 10000) / 10000), forKey: "colAlphaMem2")
+    }
+
+    private func shouldShowSecondColorControls() -> Bool {
+        return (AppDelegate.UserSettings.userWantsMemGradientColor
+                && AppDelegate.UserSettings.memUsageVisualization == AppDelegate.VisualizationType.Bar)
     }
 }

--- a/iGlance/iGlance/Utils/GradientImage.swift
+++ b/iGlance/iGlance/Utils/GradientImage.swift
@@ -1,0 +1,60 @@
+//
+//  GradientImage.swift
+//  iGlance
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Cocoa
+
+final class GradientImage {
+
+    private struct Cache {
+        let fromColor: NSColor
+        let toColor: NSColor
+        let img: NSImage
+    }
+
+    private let height: Double
+    private let width: Double
+
+    private var cache: Cache?
+
+    init(height: Double, width: Double) {
+        self.height = height
+        self.width = width
+    }
+
+    func create(fromColor: NSColor, toColor: NSColor) -> NSImage {
+        if cache?.fromColor == fromColor && cache?.toColor == toColor {
+            // return cached image if from/to colors didn't change
+            return cache!.img
+        }
+        let img = NSImage(size: NSSize(width: width, height: height))
+        let rect = NSRect(x: 0, y: 0, width: width, height: height)
+        img.lockFocus()
+        let gradient = NSGradient(starting: fromColor, ending: toColor)
+        gradient?.draw(in: rect, angle: CGFloat(90))
+        img.unlockFocus()
+        cache = Cache(fromColor: fromColor, toColor: toColor, img: img)
+        return img
+    }
+
+}


### PR DESCRIPTION
This PR adds possibility to optionally specify second color for CPU and Memory bar icons to visualise low/mid/high resource usage. Which might look like this:
![gradient_bar](https://user-images.githubusercontent.com/10883610/65086125-ecb0ec00-d9b0-11e9-91f1-2391a47743fb.gif)
Settings UI update:
![settings](https://user-images.githubusercontent.com/10883610/65086132-f20e3680-d9b0-11e9-8099-99f297f3a79f.gif)
