### PR TITLE
fix app crash when network interfaces down

### DIFF
--- a/iGlance/iGlance/Components/NetUsageComponent.swift
+++ b/iGlance/iGlance/Components/NetUsageComponent.swift
@@ -150,7 +150,7 @@ class NetUsageComponent {
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let interface = String(data: data, encoding: String.Encoding.utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        return interface ?? "en0"
+        return interface.map { $0.isEmpty ? "en0" : $0 } ?? "en0"
     }
 
     /**


### PR DESCRIPTION
fixes #67 

## Description
Before the fix ```getCurrentlyUsedNetInterface```  would return an empty string if there is no internet connection (```route get 0.0.0.0``` returns ``` route: writing to routing socket: not in table```).
This gives an exception in ```readNetUsage``` when it tries to parse unexpected ```netstat``` output. 

## Related Issue
Related to #67 
## Motivation and Context
I'm not advertising this PR as a complete fix for #40 because @D0miH also mentioned that some crashes can be related to ```GradientImage``` class. Unfortunately I cannot reproduce any gradient-related crashes on my environment. Would appreciate any hints on how to debug the issue using provided crash report (I'm not an expert on macos/swift development).  

## How Has This Been Tested?

While iGlance is running and ```Network Usage``` monitor is enabled, stop your internet interfaces (e.g. Wi-Fi). Unpatched version would crash within a second.

## Checklist

[x ] I have read the [Contribution Guide](https://github.com/iglance/iGlance/blob/master/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/iglance/iGlance/blob/master/.github/CODE_OF_CONDUCT.md)  
[x ] All checks and tests run through
