### PR TITLE
advanced logging settings is now saved in user settings

### DIFF
--- a/iGlance/iGlance/iGlance/AppDelegate.swift
+++ b/iGlance/iGlance/iGlance/AppDelegate.swift
@@ -55,11 +55,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // set the default log level to error
         dynamicLogLevel = .error
 
-        if DEBUG {
+        if AppDelegate.userSettings.settings.advancedLogging {
             // log all messages
             dynamicLogLevel = .all
-            // open the window on startup in debug mode
-            showMainWindow()
         }
 
         // call the update loop once on startup to render the menu bar items

--- a/iGlance/iGlance/iGlance/Modals/PreferenceModal/PreferenceModalViewController.swift
+++ b/iGlance/iGlance/iGlance/Modals/PreferenceModal/PreferenceModalViewController.swift
@@ -26,13 +26,13 @@ class PreferenceModalViewController: ModalViewController {
     @IBOutlet private var autostartOnBootCheckbox: NSButton! {
         didSet {
             // load the initial value from the user settings
-            autostartOnBootCheckbox.state = AppDelegate.userSettings.settings.autostartOnBoot ? NSButton.StateValue.on : NSButton.StateValue.off
+            autostartOnBootCheckbox.state = AppDelegate.userSettings.settings.autostartOnBoot ? .on : .off
         }
     }
 
     @IBOutlet private var advancedLoggingCheckbox: ThemedButton! {
         didSet {
-            advancedLoggingCheckbox.state = DEBUG ? NSButton.StateValue.on : NSButton.StateValue.off
+            advancedLoggingCheckbox.state = AppDelegate.userSettings.settings.advancedLogging ? .on : .off
         }
     }
 
@@ -123,8 +123,9 @@ class PreferenceModalViewController: ModalViewController {
     }
 
     @IBAction private func advancedLoggingCheckboxChanged(_ sender: NSButton) {
+        let activated = sender.state == .on
         // set the dynamic logging level depending on the state of the button
-        if sender.state == NSButton.StateValue.on {
+        if activated {
             dynamicLogLevel = .all
             DDLogInfo("Set the log level to 'all'")
             DDLogInfo("Activated 'Advanced Loggin'")
@@ -133,6 +134,9 @@ class PreferenceModalViewController: ModalViewController {
             DDLogInfo("Set the log level to 'error'")
             DDLogInfo("Deactivated 'Advanced Loggin'")
         }
+
+        // set the user setting
+        AppDelegate.userSettings.settings.advancedLogging = activated
     }
 
     @IBAction private func updateIntervalSelectorChanged(_ sender: NSPopUpButton) {

--- a/iGlance/iGlance/iGlance/SystemInfo/NetworkInfo.swift
+++ b/iGlance/iGlance/iGlance/SystemInfo/NetworkInfo.swift
@@ -120,7 +120,7 @@ class NetworkInfo {
 
         // get the command output
         let commandOutput = pipe.fileHandleForReading.readDataToEndOfFile()
-        
+
         DDLogInfo("Output of the network interface command: \n\(commandOutput)")
 
         // get the currently used interface

--- a/iGlance/iGlance/iGlance/UserSettings.swift
+++ b/iGlance/iGlance/iGlance/UserSettings.swift
@@ -74,6 +74,7 @@ struct BatterySettings: Codable {
 struct IGlanceUserSettings: Codable {
     // global settings
     var autostartOnBoot: Bool = false
+    var advancedLogging: Bool = DEBUG
     var updateInterval: Double = 2.0
     var tempUnit: TemperatureUnit = .celsius
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Saving the state of the `Advanced Logging` setting is more consistent than resetting it when closing the app.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #84

## Motivation and Context
Saving the setting is more transparent for the user.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->