### PR TITLE
fix diagnostics app menu

### DIFF
--- a/iGlance/iGlance/iGlance/Base.lproj/Main.storyboard
+++ b/iGlance/iGlance/iGlance/Base.lproj/Main.storyboard
@@ -115,13 +115,10 @@
                             </menuItem>
                             <menuItem title="Diagnostics" id="Fuq-kV-Ubk">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Diagnostics" systemMenu="window" id="pZ0-xF-28n">
+                                <menu key="submenu" title="Diagnostics" id="eFn-sS-dLd">
                                     <items>
-                                        <menuItem title="Save Log Files..." id="RWa-DA-MeM">
+                                        <menuItem title="Save Logfile..." id="41S-gD-t7E">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="uId-bG-tOu"/>
-                                            </connections>
                                         </menuItem>
                                     </items>
                                 </menu>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the `Move Window to Left/Right Side of Screen` option as well as the window selection menu from the diagnostics menu.

<!--- Describe your changes in detail -->

## Related Issue
fixes #93
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->