### PR TITLE
Feature/export most recent logfile 97

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,5 +26,5 @@ If applicable, add screenshots to help explain your problem.
 
 **Log**
 Please activate `Advanced Logging` in the settings, restart the app and perform the steps to reproduce the bug.
-After the bug occurred, please close the app completely (i.e. by opening the app window and pressing `CMD+Q`).
-Please take the latest log file from `~/Library/Logs/iGlance/` and upload it here.
+After the bug occurred, please open the iGlance window and in the app menu at the top left of the menu bar click on `Diagnostics > Save Logfile...`.
+Save the logfile somewhere and upload it here by dragging the file into the textfield.

--- a/iGlance/iGlance/iGlance/AppDelegate.swift
+++ b/iGlance/iGlance/iGlance/AppDelegate.swift
@@ -188,4 +188,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     static func getInstance() -> AppDelegate? {
         NSApplication.shared.delegate as? AppDelegate
     }
+
+    // MARK: -
+    // MARK: Actions
+
+    @IBAction private func saveMostRecentLogFile(sender: AnyObject) {
+        self.logger.saveMostRecentLogFile()
+    }
 }

--- a/iGlance/iGlance/iGlance/AppDelegate.swift
+++ b/iGlance/iGlance/iGlance/AppDelegate.swift
@@ -178,4 +178,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         currentUpdateLoopTimer = timer
     }
+
+    // MARK: -
+    // MARK: Static Functions
+
+    /**
+     * Returns the current instance of the app delegate class.
+     */
+    static func getInstance() -> AppDelegate? {
+        NSApplication.shared.delegate as? AppDelegate
+    }
 }

--- a/iGlance/iGlance/iGlance/Base.lproj/Main.storyboard
+++ b/iGlance/iGlance/iGlance/Base.lproj/Main.storyboard
@@ -63,21 +63,12 @@
                                     <items>
                                         <menuItem title="Import Settings..." id="aTl-1u-JFS">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
-                                            </connections>
                                         </menuItem>
                                         <menuItem title="Export Settings..." id="pEa-Tm-cAy">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="print:" target="Ady-hI-5gd" id="znB-8W-S7W"/>
-                                            </connections>
                                         </menuItem>
                                         <menuItem title="Reset Settings..." id="mjT-CA-nxz">
                                             <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="print:" target="Ady-hI-5gd" id="euZ-1j-48x"/>
-                                            </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="edB-3D-5wF"/>
                                         <menuItem title="Close" keyEquivalent="w" id="4rx-Ty-iez">
@@ -119,6 +110,9 @@
                                     <items>
                                         <menuItem title="Save Logfile..." id="41S-gD-t7E">
                                             <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="saveMostRecentLogFileWithSender:" target="Ady-hI-5gd" id="4xx-cR-Xmu"/>
+                                            </connections>
                                         </menuItem>
                                     </items>
                                 </menu>

--- a/iGlance/iGlance/iGlance/Logger.swift
+++ b/iGlance/iGlance/iGlance/Logger.swift
@@ -72,7 +72,7 @@ class Logger {
                     DDLogError("Somethings went wrong while saving the log file")
                     return
                 }
-                
+
                 DDLogInfo("The log file \(mostRecentLogFileUrl.lastPathComponent) was successfully saved")
             } else if result == .cancel {
                 DDLogInfo("The save logfile dialog was cancelled")

--- a/iGlance/iGlance/iGlance/Logger.swift
+++ b/iGlance/iGlance/iGlance/Logger.swift
@@ -34,4 +34,69 @@ class Logger {
             dynamicLogLevel = .all
         }
     }
+
+    func saveMostRecentLogFile() {
+        // get the log file paths
+        let logfilePaths = self.fileLogger.logFileManager.sortedLogFilePaths
+
+        // check if there are any log files
+        if logfilePaths.isEmpty {
+            let alert = NSAlert()
+            alert.messageText = "Error"
+            alert.informativeText = "No logfiles were found"
+            alert.addButton(withTitle: "Ok")
+            alert.runModal()
+
+            DDLogError("No log files were found")
+            return
+        }
+        let mostRecentLogFileUrl = URL(fileURLWithPath: logfilePaths.first!)
+
+        // create the save panel
+        let savePanel = NSSavePanel()
+        savePanel.nameFieldStringValue = mostRecentLogFileUrl.lastPathComponent
+
+        savePanel.begin { result in
+            if result == .OK {
+                var success = false
+                if let destUrl = savePanel.url {
+                    success = self.saveLogFile(logFileUrl: mostRecentLogFileUrl, destinationUrl: destUrl)
+                }
+
+                if !success {
+                    let alert = NSAlert()
+                    alert.messageText = "Error"
+                    alert.informativeText = "Something went wrong while saving the log file"
+                    alert.addButton(withTitle: "Ok")
+                    alert.runModal()
+                    DDLogError("Somethings went wrong while saving the log file")
+                    return
+                }
+                
+                DDLogInfo("The log file \(mostRecentLogFileUrl.lastPathComponent) was successfully saved")
+            } else if result == .cancel {
+                DDLogInfo("The save logfile dialog was cancelled")
+            }
+        }
+    }
+
+    /**
+     * Saves the log file which is located at the given path to the given destination path.
+     *
+     *  - Parameter logFileUrl: The url of the log file that is going to be saved.
+     *  - Parameter destinationUrl: The url of the destination where the log file is going to be saved.
+     */
+    func saveLogFile(logFileUrl: URL, destinationUrl: URL) -> Bool {
+        // get the default file manager of the process
+        let fileManager = FileManager.default
+
+        // copy the log file to the destination
+        do {
+            try fileManager.copyItem(at: logFileUrl, to: destinationUrl)
+            return true
+        } catch {
+            DDLogError("Failed to copy the log file to the destination")
+            return false
+        }
+    }
 }

--- a/iGlance/iGlance/iGlance/MainWindow/MainWindowController.swift
+++ b/iGlance/iGlance/iGlance/MainWindow/MainWindowController.swift
@@ -51,6 +51,9 @@ class MainWindowController: NSWindowController {
         self.window?.center()
     }
 
+    // MARK: -
+    // MARK: Private Functions
+
     @objc
     private func updateMainWindow() {
         mainWindow.backgroundColor = ThemeManager.currentTheme().titlebarColor

--- a/iGlance/iGlance/iGlance/Modals/PreferenceModal/PreferenceModalViewController.swift
+++ b/iGlance/iGlance/iGlance/Modals/PreferenceModal/PreferenceModalViewController.swift
@@ -154,8 +154,11 @@ class PreferenceModalViewController: ModalViewController {
         }
 
         // update the update loop timer
-        let appDelegate = NSApplication.shared.delegate as! AppDelegate
-        appDelegate.changeUpdateLoopTimeInterval(interval: AppDelegate.userSettings.settings.updateInterval)
+        if let appDelegate = AppDelegate.getInstance() {
+            appDelegate.changeUpdateLoopTimeInterval(interval: AppDelegate.userSettings.settings.updateInterval)
+        } else {
+            DDLogError("Could not retrieve the App Delegate Instance")
+        }
     }
 
     @IBAction private func tempUnitSelectorChanged(_ sender: NSPopUpButton) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The user can now easily save the most recent log file using the app menu under `Diagnostics
<!--- Describe your changes in detail -->

## Related Issue
closes #97 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Before this feature the user had to manually navigate to `~/Library/Logs/iGlance`, search for the most recent logfile and copy it somewhere else. Now the user can easily export/save the most recent log file by pressing one button.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

