### PR TITLE
Free memory is now correctly calculated

### DIFF
--- a/iGlance/iGlance/iGlance/MenuBarItems/MemoryUsageMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/MemoryUsageMenuBarItem.swift
@@ -89,6 +89,6 @@ class MemoryUsageMenuBarItem: MenuBarItem {
         activeMemoryMenuEntry.title = "Active: \t\t\t \(String(format: "%.2f", memoryUsage.active)) GB"
         wiredMemoryMenuEntry.title = "Wired: \t\t\t \(String(format: "%.2f", memoryUsage.wired)) GB"
         compressedMemoryMenuEntry.title = "Compressed: \t \(String(format: "%.2f", memoryUsage.compressed)) GB"
-        freeMemoryMenuEntry.title = "Free: \t\t\t \(String(format: "%.2f", memoryUsage.free)) GB"
+        freeMemoryMenuEntry.title = "Free: \t\t\t \(String(format: "%.2f", memoryUsage.free + memoryUsage.inactive)) GB"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The free memory value in the memory menu bar menu was wrong. Instead of just printing the free memory, the unused memory is now calculated by adding the "free" and the "inactive" memory.
<!--- Describe your changes in detail -->

## Related Issue
fixes #123
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
