### PR TITLE
Fixed drawing of bar graph when current value is zero

### DIFF
--- a/iGlance/iGlance/iGlance/Graphs/BarGraph.swift
+++ b/iGlance/iGlance/iGlance/Graphs/BarGraph.swift
@@ -108,7 +108,9 @@ class BarGraph: Graph {
         image.lockFocus()
 
         // get the height of the bar
-        let barHeight = Double((maxBarHeight / self.maxValue) * currentValue)
+        // prevent a value of zero since this would cause a bug when drawing the bar
+        let value = (currentValue == 0 ? 0.1 : currentValue)
+        let barHeight = Double((maxBarHeight / self.maxValue) * value)
 
         // draw the gradient if necessary
         if gradientColor != nil {

--- a/iGlance/iGlance/iGlance/MenuBarItems/Cpu/CpuUsageMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/Cpu/CpuUsageMenuBarItem.swift
@@ -77,7 +77,7 @@ class CpuUsageMenuBarItem: MenuBarItem {
         }
 
         // add the value to the line graph history
-        // this allows us to draw the resent history when the user switches to the line graph
+        // this allows us to draw the recent history when the user switches to the line graph
         self.lineGraph.addValue(value: Double(totalUsage))
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed a bug that would cause the bar graph to be drawn wrong when the current value of the cpu usage is zero.
<!--- Describe your changes in detail -->

## Related Issue
fixes #127 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
