### PR TITLE
appcast.xml: fix 2.0.4 enclosure url

### DIFF
--- a/Sparkle/updates/appcast.xml
+++ b/Sparkle/updates/appcast.xml
@@ -57,7 +57,7 @@
             </sparkle:releaseNotesLink>
             <pubDate>Wed, 01 Apr 2020 19:37:22 +0200</pubDate>
             <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/iglance/iGlance/releases/download/v2.0.3/iGlance_v2.0.4.zip" sparkle:version="2.0.4" sparkle:shortVersionString="2.0.4" length="10105711" type="application/octet-stream" sparkle:edSignature="74m8D2j62xSrp4OYNjCqmbchhAOZUeo14k96CkU/VYmvPwMoxV7bubnvkYf5725cWNYeCko2yIuz7yJnMV6xBQ=="/>
+            <enclosure url="https://github.com/iglance/iGlance/releases/download/v2.0.4/iGlance_v2.0.4.zip" sparkle:version="2.0.4" sparkle:shortVersionString="2.0.4" length="10105711" type="application/octet-stream" sparkle:edSignature="74m8D2j62xSrp4OYNjCqmbchhAOZUeo14k96CkU/VYmvPwMoxV7bubnvkYf5725cWNYeCko2yIuz7yJnMV6xBQ=="/>
             <sparkle:deltas>
                 <enclosure url="https://raw.githubusercontent.com/iglance/iGlance/master/Sparkle/updates/iGlance2.0.4-2.0.3.delta" sparkle:version="2.0.4" sparkle:shortVersionString="2.0.4" sparkle:deltaFrom="2.0.3" length="227329" type="application/octet-stream" sparkle:edSignature="6j1j4HK9Kh/OT4DHFOk2zq4cmF0hJBQEXvBgTbOaQG4e3HnoAX5KkCgiR8wGuRwXEnN91i7uub+jLkQl7PF+CQ=="/>
                 <enclosure url="https://raw.githubusercontent.com/iglance/iGlance/master/Sparkle/updates/iGlance2.0.4-2.0.2.delta" sparkle:version="2.0.4" sparkle:shortVersionString="2.0.4" sparkle:deltaFrom="2.0.2" length="245727" type="application/octet-stream" sparkle:edSignature="r9pBlfBaLkdpp3oVEMHo8yN+66O5KrTQztal+SH1EXzjYMrKHyon4tX32RsSVFeA+5qFMPVCnvSzuoqf7Q+SCg=="/>


### PR DESCRIPTION
## Description

The current sparkle feed pointed to the wrong download URL for the latest version.

## Related Issue

```
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
```

Opening an issue and having a discussion for a single character change seems excessive. But if that’s a deal breaker, so be it. I don’t use the app and noticed the issue while working on something else.

## Motivation and Context

Required for Sparkle checks to work properly.