### PR TITLE
if the cpu usage value is zero the graph is not drawing anything

### DIFF
--- a/iGlance/iGlance/iGlance/Graphs/BarGraph.swift
+++ b/iGlance/iGlance/iGlance/Graphs/BarGraph.swift
@@ -104,13 +104,16 @@ class BarGraph: Graph {
      * Takes an image and draws the bar on the given image
      */
     private func drawBarGraph(image: inout NSImage, currentValue: Double, barColor: NSColor, gradientColor: NSColor?) {
+        // if the current value is zero we don't have to draw anything and can return immediately
+        if currentValue == 0 {
+            return
+        }
+
         // lock the focus on the image in order to draw on it
         image.lockFocus()
 
         // get the height of the bar
-        // prevent a value of zero since this would cause a bug when drawing the bar
-        let value = (currentValue == 0 ? 0.1 : currentValue)
-        let barHeight = Double((maxBarHeight / self.maxValue) * value)
+        let barHeight = Double((maxBarHeight / self.maxValue) * currentValue)
 
         // draw the gradient if necessary
         if gradientColor != nil {

--- a/iGlance/iGlance/iGlance/Graphs/LineGraph.swift
+++ b/iGlance/iGlance/iGlance/Graphs/LineGraph.swift
@@ -84,6 +84,11 @@ class LineGraph: Graph {
         // iterate the values and draw a bar for each value on the correct position
         var nextValuePosition = self.imageSize.width - self.borderWidth - 1
         for value in valueHistory.makeIterator().reversed() {
+            // if the value is zero we don't have to draw anything and can continue with the loop
+            if value == 0 {
+                continue
+            }
+
             // calculate the height of the bar
             let barHeight = Double((self.maxbarHeight / self.maxValue) * value)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The cpu usage line graph no longer draws spikes when the total cpu usage is zero.
<!--- Describe your changes in detail -->

## Related Issue
fix #141 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
