### PR TITLE
checkbox is now set when the view is instantiated

### DIFF
--- a/iGlance/iGlance/iGlance/MainWindow/MainViews/NetworkViewController.swift
+++ b/iGlance/iGlance/iGlance/MainWindow/MainViews/NetworkViewController.swift
@@ -19,7 +19,11 @@ import CocoaLumberjack
 class NetworkViewController: MainViewViewController {
     // MARK: -
     // MARK: Outlets
-    @IBOutlet private var networkUsageCheckbox: NSButton!
+    @IBOutlet private var networkUsageCheckbox: NSButton! {
+        didSet {
+            networkUsageCheckbox.state = AppDelegate.userSettings.settings.network.showBandwidth ? .on : .off
+        }
+    }
 
     // MARK: -
     // MARK: Actions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`Show network usage` checkbox is now correctly set according to the use settings when the view is instantiated
<!--- Describe your changes in detail -->

## Related Issue
closes #136 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
