### PR TITLE
fixed caching of the memory bar graph images

### DIFF
--- a/iGlance/iGlance/iGlance/Graphs/BarGraph.swift
+++ b/iGlance/iGlance/iGlance/Graphs/BarGraph.swift
@@ -64,8 +64,11 @@ class BarGraph: Graph {
      * Returns the bar graph image for the menu bar.
      */
     func getImage(currentValue: Double, graphColor: NSColor, drawBorder: Bool, gradientColor: NSColor?) -> NSImage {
+        // get the rounded bar height
+        var barHeight = Double((maxBarHeight / self.maxValue) * currentValue)
+        barHeight = Double(round(barHeight * 100) / 100)
         // check whether we need to redraw the graph
-        let key = Key(value: currentValue, isDarkTheme: ThemeManager.isDarkTheme())
+        let key = Key(value: barHeight, isDarkTheme: ThemeManager.isDarkTheme())
 
         if imageCache[key] != nil {
             DDLogInfo("Using image from cache")
@@ -114,7 +117,9 @@ class BarGraph: Graph {
         image.lockFocus()
 
         // get the height of the bar
-        let barHeight = Double((maxBarHeight / self.maxValue) * currentValue)
+        var barHeight = Double((maxBarHeight / self.maxValue) * currentValue)
+        // round the height to two decimal places
+        barHeight = Double(round(barHeight * 100) / 100)
 
         // draw the gradient if necessary
         if gradientColor != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The key for caching the bar graph images of the memory menu bar graph was using the exact total memory value. However, because this value had like 7 decimal places the image was cached on every update call. 
Now the current total memory value is rounded to 2 decimal places which should reduce the times the image has to be cached.

## Related Issue
closes #177 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
