### PR TITLE
On first startup it is checked whether a battery exists

### DIFF
--- a/iGlance/iGlance/iGlance/UserSettings.swift
+++ b/iGlance/iGlance/iGlance/UserSettings.swift
@@ -64,7 +64,7 @@ struct BatteryNotificationSettings: Codable {
 }
 
 struct BatterySettings: Codable {
-    var showBatteryMenuBarItem: Bool = true
+    var showBatteryMenuBarItem: Bool = AppDelegate.systemInfo.battery.hasBattery()
     /// Is true when the percentage of the battery charge is displayed. If the value is false, the remaining time is displayed instead
     var showPercentage: Bool = false
     var lowBatteryNotification = BatteryNotificationSettings(notifyUser: true, value: 20)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
On first startup it is now checked whether a battery is present on the current machine. If this is not the case the battery status icon will not be displayed.

## Related Issue
closes #179 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
