### PR TITLE
Bug fix/178 battery notifications are discarded to fast

### DIFF
--- a/iGlance/iGlance/iGlance/MenuBarItems/BatteryMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/BatteryMenuBarItem.swift
@@ -67,8 +67,6 @@ class BatteryMenuBarItem: MenuBarItem {
         updateMenuBarIcon(currentCharge: currentCharge, isOnAC: isOnAC, isCharging: isCharging, isCharged: isCharged, batteryState: batteryState)
         updateMenuBarMenu(currentCharge: currentCharge, batteryState: batteryState)
 
-        // remove all previous sent notifications
-        NSUserNotificationCenter.default.removeAllDeliveredNotifications()
         // notify the user about the capacity of the battery if necessary
         if AppDelegate.userSettings.settings.battery.lowBatteryNotification.notifyUser {
             deliverLowBatteryNotification(currentCharge: currentCharge)
@@ -328,6 +326,10 @@ class BatteryMenuBarItem: MenuBarItem {
 
         if self.lastBatteryCharge > lowThreshold && currentCharge <= lowThreshold {
             deliverNotification(title: "Battery Info", message: "Battery is low", identifier: BATTERY_NOTIFICATION_IDENTIFIER)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
+                DDLogInfo("Removing all delivered notifications")
+                NSUserNotificationCenter.default.removeAllDeliveredNotifications()
+            }
         }
     }
 
@@ -341,6 +343,10 @@ class BatteryMenuBarItem: MenuBarItem {
 
         if self.lastBatteryCharge < highThreshold &&  currentCharge >= highThreshold {
             deliverNotification(title: "Battery Info", message: "Battery is almost fully charged", identifier: BATTERY_NOTIFICATION_IDENTIFIER)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) {
+                DDLogInfo("Removing all delivered notifications")
+                NSUserNotificationCenter.default.removeAllDeliveredNotifications()
+            }
         }
     }
 

--- a/iGlance/iGlance/iGlance/UserSettings.swift
+++ b/iGlance/iGlance/iGlance/UserSettings.swift
@@ -64,7 +64,7 @@ struct BatteryNotificationSettings: Codable {
 }
 
 struct BatterySettings: Codable {
-    var showBatteryMenuBarItem: Bool = true
+    var showBatteryMenuBarItem: Bool = AppDelegate.systemInfo.battery.hasBattery()
     /// Is true when the percentage of the battery charge is displayed. If the value is false, the remaining time is displayed instead
     var showPercentage: Bool = false
     var lowBatteryNotification = BatteryNotificationSettings(notifyUser: true, value: 20)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Battery notifications are now visible for 4 seconds before they are discarded.

## Related Issue
closes #178 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
