### PR TITLE
Invisible/transparent icons in menu bar

### DIFF
--- a/iGlance/iGlance/iGlance/Theme/ThemeManager.swift
+++ b/iGlance/iGlance/iGlance/Theme/ThemeManager.swift
@@ -73,7 +73,20 @@ class ThemeManager {
      * - Returns: True if dark mode is enabled. Returns false otherwise.
      */
     static func isDarkTheme() -> Bool {
-        UserDefaults.standard.string(forKey: "AppleInterfaceStyle") != nil
+        var darkTheme = false
+
+        // Special thanks to @ruiaureliano <https://github.com/ruiaureliano> for investigating this issue and providing
+        // a fix: https://github.com/ruiaureliano/macOS-Appearance/blob/master/Appearance/Source/AppDelegate.swift
+        if #available(OSX 10.15, *) {
+            let appearanceDesc = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
+            darkTheme = appearanceDesc.contains("dark")
+        } else if #available(OSX 10.14, *) {
+            if let interfaceStyle = UserDefaults.standard.object(forKey: "AppleInterfaceStyle") as? String {
+                darkTheme = interfaceStyle.lowercased().contains("dark")
+            }
+        }
+
+        return darkTheme
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR should fix the issue that the menu bar icons are not reacting to the `Automatic Appearance` change.
For osx 10.15 and greater the `effectiveAppearance` is now used to check if dark mode is active.
<!--- Describe your changes in detail -->
## Related Issue
closes #183
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
