### PR TITLE
Update ThemeManager.swift

### DIFF
--- a/iGlance/iGlance/iGlance/Theme/ThemeManager.swift
+++ b/iGlance/iGlance/iGlance/Theme/ThemeManager.swift
@@ -61,7 +61,7 @@ enum Theme: Int {
         case .darkTheme:
             return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         case .lightTheme:
-            return #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
+            return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
         }
     }
 


### PR DESCRIPTION
On light theme, there was an issue about the font color. On light theme black color is really bad on Big Sur.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There was an issue about the font color when light theme activated. So I changed font color to white on light theme
optionally we can only do this change on Big Sur. This code may work

```
#if compiler(>=5.3)
if @available(macOS 11.0, *) {
// use some new API
}
#endif
```

or 

```
#if compiler(>=5.3)
if @available(macOS 10.16, *) {
// use some new API
}
#endif
```

I found there is 
```let fontColor = ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black```
codes on menubar items, also there is icon colors if available. I tested and checked but this is only on Big Sur. If other versions is right. I can create macOS version selector. What's your idea

## Related Issue
![image](https://user-images.githubusercontent.com/8514643/101212510-e37d6f00-3689-11eb-9de7-eec7c63bf2dc.png)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
