### PR TITLE
Fix MacOS Big Sur Dark/Light theme font/border color issue

### DIFF
--- a/iGlance/iGlance/iGlance/Graphs/Graph.swift
+++ b/iGlance/iGlance/iGlance/Graphs/Graph.swift
@@ -100,7 +100,11 @@ class GraphClass {
         if ThemeManager.isDarkTheme() {
             NSColor.white.set()
         } else {
-            NSColor.black.set()
+            if #available(macOS 11.0, *) {
+                NSColor.white.set()
+            } else {
+                NSColor.black.set()
+            }
         }
 
         // draw the border

--- a/iGlance/iGlance/iGlance/MenuBarItems/BatteryMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/BatteryMenuBarItem.swift
@@ -126,8 +126,16 @@ class BatteryMenuBarItem: MenuBarItem {
         // render the string
         buttonString.draw(at: NSPoint(x: image.size.width - buttonString.size().width, y: image.size.height / 2 - buttonString.size().height / 2))
 
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // tint the battery icon to match it to the theme of the os
-        let tintedBatteryIcon = batteryIcon!.tint(color: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black)
+        let tintedBatteryIcon = batteryIcon!.tint(color: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite())
         // render the battery icon
         tintedBatteryIcon.draw(at: NSPoint(x: 0, y: 18 / 2 - tintedBatteryIcon.size.height / 2), from: NSRect.zero, operation: .sourceOver, fraction: 1.0)
 
@@ -194,10 +202,18 @@ class BatteryMenuBarItem: MenuBarItem {
     private func getRemainingTimeString(batteryState: InternalBatteryState) -> NSAttributedString {
         var buttonString: NSAttributedString
 
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // define the attributes
         let attributes = [
             NSAttributedString.Key.font: NSFont.systemFont(ofSize: 13),
-            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()
         ]
 
         switch batteryState {
@@ -227,10 +243,18 @@ class BatteryMenuBarItem: MenuBarItem {
         let timeToFull = convertMinutesToHours(minutes: timeToFullMinutes)
         let timeToFullString = "\(timeToFull.hours):\(String(format: "%02d", timeToFull.minutes))"
 
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // define the attributes
         let attributes = [
             NSAttributedString.Key.font: NSFont.systemFont(ofSize: 13),
-            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()
         ]
 
         return NSAttributedString(string: timeToFullString, attributes: attributes)
@@ -245,10 +269,18 @@ class BatteryMenuBarItem: MenuBarItem {
         let timeToEmpty = convertMinutesToHours(minutes: timeToEmptyMinutes)
         let timeToEmptyString = "\(timeToEmpty.hours):\(String(format: "%02d", timeToEmpty.minutes))"
 
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // define the attributes
         let attributes = [
             NSAttributedString.Key.font: NSFont.systemFont(ofSize: 13),
-            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()
         ]
 
         return NSAttributedString(string: timeToEmptyString, attributes: attributes)
@@ -272,10 +304,18 @@ class BatteryMenuBarItem: MenuBarItem {
      * Returns the string that is displaying the current charge of the battery in percentage.
      */
     private func getPercentageString(currentCharge: Int) -> NSAttributedString {
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // define the attributes
         let attributes = [
             NSAttributedString.Key.font: NSFont.systemFont(ofSize: 13),
-            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()
         ]
 
         return NSAttributedString(string: "\(currentCharge)%", attributes: attributes)
@@ -312,8 +352,17 @@ class BatteryMenuBarItem: MenuBarItem {
 
         // create and draw the charge indicator rectangle as a rounded rectangle
         let chargeBar = NSRect(x: borderWidth + chargeBarMargin, y: borderWidth + chargeBarMargin, width: chargeBarWidth, height: chargeBarCurrentHeight)
+
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         let roundedRect = NSBezierPath(roundedRect: chargeBar, xRadius: 1.5, yRadius: 1.5)
-        (ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black).set()
+        (ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()).set()
         roundedRect.fill()
 
         // unlock the focus

--- a/iGlance/iGlance/iGlance/MenuBarItems/Cpu/CpuTempMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/Cpu/CpuTempMenuBarItem.swift
@@ -72,9 +72,15 @@ class CpuTempMenuBarItem: MenuBarItem {
         let font = NSFont.systemFont(ofSize: 13)
 
         attribString.addAttribute(.font, value: font, range: NSRange(location: 0, length: string.count))
-        let fontColor = ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
-        attribString.addAttribute(.foregroundColor, value: fontColor, range: NSRange(location: 0, length: string.count))
 
-        return attribString
+        if #available(macOS 11.0, *) {
+            let fontColor = NSColor.white
+            attribString.addAttribute(.foregroundColor, value: fontColor, range: NSRange(location: 0, length: string.count))
+            return attribString
+        } else {
+            let fontColor = ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            attribString.addAttribute(.foregroundColor, value: fontColor, range: NSRange(location: 0, length: string.count))
+            return attribString
+        }
     }
 }

--- a/iGlance/iGlance/iGlance/MenuBarItems/DiskUsageMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/DiskUsageMenuBarItem.swift
@@ -115,12 +115,20 @@ class DiskUsageMenuBarItem: MenuBarItem {
      * Creates an attributed string that can be drawn on the menu bar image.
      */
     private func createAttributedString(text: String) -> NSAttributedString {
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         let attrString = NSMutableAttributedString(
             string: text,
             attributes: [
                 NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9),
                 NSAttributedString.Key.kern: 1.2,
-                NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+                NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()
             ]
         )
 

--- a/iGlance/iGlance/iGlance/MenuBarItems/FanMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/FanMenuBarItem.swift
@@ -140,10 +140,18 @@ class FanMenuBarItem: MenuBarItem {
         // create the attributed string
         let string = String(value) + " " + (unit ? "RPM" : "")
 
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // define the attributes
         let attributes = [
             NSAttributedString.Key.font: NSFont.systemFont(ofSize: 13),
-            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            NSAttributedString.Key.foregroundColor: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite()
         ]
 
         // create the string

--- a/iGlance/iGlance/iGlance/MenuBarItems/Network/NetworkMenuBarItem.swift
+++ b/iGlance/iGlance/iGlance/MenuBarItems/Network/NetworkMenuBarItem.swift
@@ -170,6 +170,8 @@ class NetworkMenuBarItem: MenuBarItem {
         self.totalBytesOnLastReset[interfaceName] = AppDelegate.systemInfo.network.getTotalTransmittedBytesOf(interface: interfaceName)
     }
 
+
+
     /**
      * Returns the image that can be rendered on the menu bar.
      */
@@ -181,13 +183,23 @@ class NetworkMenuBarItem: MenuBarItem {
         let uploadString = self.createAttributedBandwidthString(value: valueStringUp, unit: up.unit.rawValue + "/s")
         let downloadString = self.createAttributedBandwidthString(value: valueStringDown, unit: down.unit.rawValue + "/s")
 
+        func blackOrWhite() -> NSColor {
+            var returnColor = NSColor.black
+            if #available(macOS 11.0, *) {
+                returnColor = NSColor.white
+            }
+            return returnColor
+        }
+
         // get the up arrow icon
-        guard let arrowUpIcon = NSImage(named: "ArrowUpIcon")?.tint(color: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black) else {
+        guard let arrowUpIcon = NSImage(named: "ArrowUpIcon")?.tint(color: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite())
+        else {
             DDLogError("An error occurred while loading the bandwidth arrow up menu bar icon")
             return nil
         }
         // get the down arrow icon
-        guard let arrowDownIcon = NSImage(named: "ArrowDownIcon")?.tint(color: ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black) else {
+        guard let arrowDownIcon = NSImage(named: "ArrowDownIcon")?.tint(color: ThemeManager.isDarkTheme() ? NSColor.white : blackOrWhite())
+        else {
             DDLogError("An error occurred while loading the bandwidth arrow down menu bar icon")
             return nil
         }
@@ -260,9 +272,17 @@ class NetworkMenuBarItem: MenuBarItem {
         attrString.addAttribute(.font, value: font, range: NSRange(location: 0, length: attrString.length - 1 - unit.count))
         attrString.addAttribute(.kern, value: 1.2, range: NSRange(location: 0, length: attrString.length - 1 - unit.count))
         attrString.addAttribute(.font, value: font, range: NSRange(location: attrString.length - unit.count, length: unit.count))
-        let fontColor = ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
-        attrString.addAttribute(.foregroundColor, value: fontColor, range: NSRange(location: 0, length: attrString.length))
 
-        return attrString
+        if #available(macOS 11.0, *) {
+            let fontColor = NSColor.white
+            attrString.addAttribute(.foregroundColor, value: fontColor, range: NSRange(location: 0, length: attrString.length))
+
+            return attrString
+        } else {
+            let fontColor = ThemeManager.isDarkTheme() ? NSColor.white : NSColor.black
+            attrString.addAttribute(.foregroundColor, value: fontColor, range: NSRange(location: 0, length: attrString.length))
+
+            return attrString
+        }
     }
 }


### PR DESCRIPTION
On light theme, there was an issue about the font color. On light theme black color is really bad on Big Sur.

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There was an issue about the font color when light theme was activated. So I changed font color and graph border color to white on light theme only on Big Sur.

So I changed these codes and I tested on my Mac.

## Related Issue
Before:
![image](https://user-images.githubusercontent.com/8514643/101212510-e37d6f00-3689-11eb-9de7-eec7c63bf2dc.png)
After:
![image](https://user-images.githubusercontent.com/8514643/101283014-42a5c580-37e9-11eb-99ee-64065e2021fd.png)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
