### PR TITLE
update brew install instructions to work with latest brew distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are two possible ways to install iGlance:
 1. Download the iGlance.dmg from https://github.com/iglance/iGlance/releases and manually move the app into the applications folder.
 2. Install iGlance using [brew](https://brew.sh):
 
-   `brew cask install iglance`
+   `brew install --cask iglance`
 
 # Contribute
 


### PR DESCRIPTION
## Description
The brew install instructions are out of date

old
```
brew cask install iglance
```

new
```
brew install --cask iglance
```
## Related Issue
[Issue 252](https://github.com/iglance/iGlance/issues/252)
