### PR TITLE
Bug fix/239 settings not saved

### DIFF
--- a/iGlance/iGlance/iGlance/UserSettings.swift
+++ b/iGlance/iGlance/iGlance/UserSettings.swift
@@ -177,7 +177,7 @@ struct BatterySettings: Codable {
             self.showBatteryIcon = showBatteryIcon
         }
 
-        if let decodedShowPercentage = try? container.decodeIfPresent(Bool.self, forKey: .showBatteryMenuBarItem) {
+        if let decodedShowPercentage = try? container.decodeIfPresent(Bool.self, forKey: .showPercentage) {
             self.showPercentage = decodedShowPercentage
         }
 
@@ -225,8 +225,8 @@ struct IGlanceUserSettings: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         // decode the keys, if they are not present use the default values
-        if let decodedAutostartOnBoot = try? container.decodeIfPresent(String.self, forKey: .autostartOnBoot) {
-            self.autostartOnBoot = decodedAutostartOnBoot.lowercased() == "true"
+        if let decodedAutostartOnBoot = try? container.decodeIfPresent(Bool.self, forKey: .autostartOnBoot) {
+            self.autostartOnBoot = decodedAutostartOnBoot
         }
         if let decodedAdvancedLogging = try? container.decodeIfPresent(Bool.self, forKey: .advancedLogging) {
             self.advancedLogging = decodedAdvancedLogging


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Hi, i noticed the same buggy behavior of a few settings in iGlance and decided to take a look myself and fix it. It seems someone else spotted it too and opened an issue (link below).

Bug was simple to track down. Here's a summary:
- Battery percentage/time left setting was wrongly getting another boolean value.
- Autostart on Boot was saved correctly, but decoded as string hence always was false at the time of launch.

<!--- Describe your changes in detail -->
## Related Issue
https://github.com/iglance/iGlance/issues/239
